### PR TITLE
TASK: Make "admins"-Setting optional

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -190,7 +190,7 @@ class LoginController extends ActionController
         $roles = array();
         if ($username !== null) {
             $roles = $this->settingsConfiguration['roles']['default'];
-            if (in_array($username, $this->settingsConfiguration['admins'])) {
+            if (isset($this->settingsConfiguration['admins']) && in_array($username, $this->settingsConfiguration['admins'])) {
                 $roles = array_merge($roles, $this->settingsConfiguration['roles']['admin']);
             }
         }


### PR DESCRIPTION
If all users are administrators,
the "admins" setting can be omitted.