### PR TITLE
Fix logger parameter order PSR compatibility

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -120,7 +120,7 @@ class LoginController extends ActionController
                 $this->attachWallpaperFromSettings();
 
             } catch (\Exception $e) {
-                $this->logger->log('Authentication failed: ' . $e->getMessage(), LOG_ALERT);
+                $this->logger->alert('Authentication failed: ' . $e->getMessage());
                 exit('Authentication failed: ' . $e->getMessage());
             }
         }


### PR DESCRIPTION
The old flow logger used the format with message first and level second, however the PSR-3 standard which came with Neos 5.x uses the log level first or more decleratively the alert method, this fixes that usage inline with the composer.